### PR TITLE
[Fix] Fixed JMS connection URL to exclude the destination Name + huge latencies handling

### DIFF
--- a/maestro-workers/maestro-worker-jms/src/main/java/net.orpiske.mpt.maestro.worker.jms/JMSClient.java
+++ b/maestro-workers/maestro-worker-jms/src/main/java/net.orpiske.mpt.maestro.worker.jms/JMSClient.java
@@ -65,7 +65,8 @@ class JMSClient implements Client {
         Connection connection = null;
         try {
             final URI uri = new URI(url);
-            final String connectionUrl = filterURL();
+            final String path = uri.getPath();
+            final String connectionUrl = filterURL().replace(path,"");
             final URLQuery urlQuery = new URLQuery(uri);
 
             final String protocolName = urlQuery.getString("protocol", JMSProtocol.AMQP.name());
@@ -75,7 +76,7 @@ class JMSClient implements Client {
             final ConnectionFactory factory = protocol.createConnectionFactory(connectionUrl);
             //doesn't need to use any enum yet
             final String type = urlQuery.getString("type", "queue");
-            final String destinationName = uri.getPath().substring(1);
+            final String destinationName = path.substring(1);
             switch (type) {
                 case "queue":
                     logger.debug("Creating a queue-based destination");

--- a/maestro-workers/maestro-worker-jms/src/main/java/net.orpiske.mpt.maestro.worker.jms/JMSReceiverWorker.java
+++ b/maestro-workers/maestro-worker-jms/src/main/java/net.orpiske.mpt.maestro.worker.jms/JMSReceiverWorker.java
@@ -142,7 +142,7 @@ public class JMSReceiverWorker implements MaestroReceiverWorker {
                     } else if (elapsedMicros == 0) {
                         logger.warn("Registered Latency of 0: please consider to improve timestamp precision");
                     } else if (elapsedMicros > HIGHEST_TRACKABLE_VALUE) {
-                        handleNegativeSampleError(sendTimeEpochMicros, nowInMicros);
+                        handleHugeSampleError(sendTimeEpochMicros, nowInMicros);
                         //record it but avoid histogram to throw any error
                         elapsedMicros = HIGHEST_TRACKABLE_VALUE;
                     }


### PR DESCRIPTION
The connection URL doesn't include anymore the destination name 