### PR TITLE
[Fix] Fixed mpt-data-plotter dependencies to match the latest one + updated plotter to use the last API changes

### DIFF
--- a/maestro-reports/pom.xml
+++ b/maestro-reports/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>net.orpiske</groupId>
             <artifactId>mpt-data-plotter</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
 
         <dependency>

--- a/maestro-reports/src/main/java/net/orpiske/mpt/reports/ReportGenerator.java
+++ b/maestro-reports/src/main/java/net/orpiske/mpt/reports/ReportGenerator.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/maestro-reports/src/main/java/net/orpiske/mpt/reports/plotter/RatePlotter.java
+++ b/maestro-reports/src/main/java/net/orpiske/mpt/reports/plotter/RatePlotter.java
@@ -27,11 +27,11 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;
+import java.util.List;
 
 public class RatePlotter implements Plotter {
     private static final Logger logger = LoggerFactory.getLogger(RatePlotter.class);
     private RateDataProcessor rateDataProcessor = new RateDataProcessor();
-    private RateReader rateReader = new RateReader(rateDataProcessor);
 
     @Override
     public boolean plot(File file) {
@@ -46,20 +46,19 @@ public class RatePlotter implements Plotter {
                 throw new IOException("File " + file.getPath() + " does not exist");
             }
 
-            rateReader.read(file.getPath());
+            RateReader.read(file.getPath(), rateDataProcessor::process);
 
             RateData rateData = rateDataProcessor.getRateData();
 
             // Plotter
-            net.orpiske.mdp.plot.RatePlotter plotter = new net.orpiske.mdp.plot.RatePlotter(FilenameUtils.removeExtension(baseName));
-            logger.debug("Number of records to plot: {} ", rateData.getRatePeriods().size());
-//            for (Date d : rateData.getRatePeriods()) {
-//                logger.debug("Adding date record for plotting: {}", d);
-//            }
+            final net.orpiske.mdp.plot.RatePlotter plotter = new net.orpiske.mdp.plot.RatePlotter(FilenameUtils.removeExtension(baseName));
+            final List<Date> ratePeriods = rateData.getRatePeriods();
+            logger.debug("Number of records to plot: {} ", ratePeriods.size());
+
 
             plotter.setOutputWidth(1024);
             plotter.setOutputHeight(600);
-            plotter.plot(rateData.getRatePeriods(), rateData.getRateValues());
+            plotter.plot(ratePeriods, rateData.getRateValues());
 
             RatePropertyWriter.write(rateData, file.getParentFile());
 


### PR DESCRIPTION
This need to be work in tandem with https://github.com/orpiske/mpt-data-plotter/pull/2
